### PR TITLE
Use local date helper for reservations and stats

### DIFF
--- a/src/components/Admin/AdminPanel.tsx
+++ b/src/components/Admin/AdminPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Settings, BarChart3, Users, MapPin, Calendar, Plus } from 'lucide-react';
 import { useSpaces } from '../../context/SpaceContext';
 import { useReservations } from '../../context/ReservationContext';
+import { getTodayLocalISO } from '../../utils/dateUtils';
 import SpaceForm from '../Spaces/SpaceForm';
 
 const AdminPanel: React.FC = () => {
@@ -12,8 +13,8 @@ const AdminPanel: React.FC = () => {
   const activeSpaces = spaces.filter(space => space.isActive);
   const inactiveSpaces = spaces.filter(space => !space.isActive);
   const totalReservations = reservations.filter(r => r.status !== 'cancelled').length;
-  const todayReservations = reservations.filter(r => 
-    r.date === new Date().toISOString().split('T')[0] && r.status !== 'cancelled'
+  const todayReservations = reservations.filter(r =>
+    r.date === getTodayLocalISO() && r.status !== 'cancelled'
   ).length;
 
   const spaceTypeStats = spaces.reduce((acc, space) => {

--- a/src/components/Reservations/ReservationModal.tsx
+++ b/src/components/Reservations/ReservationModal.tsx
@@ -3,7 +3,7 @@ import { X, Calendar, Clock, User, Save } from 'lucide-react';
 import { useSpaces } from '../../context/SpaceContext';
 import { useReservations } from '../../context/ReservationContext';
 import { useAuth } from '../../context/AuthContext';
-import { timeToMinutes, isTimeInRange } from '../../utils/dateUtils';
+import { timeToMinutes, isTimeInRange, getTodayLocalISO } from '../../utils/dateUtils';
 
 interface ReservationModalProps {
   spaceId: string;
@@ -32,7 +32,7 @@ const ReservationModal: React.FC<ReservationModalProps> = ({ spaceId, onClose })
 
   useEffect(() => {
     // Set minimum date to today
-    const today = new Date().toISOString().split('T')[0];
+    const today = getTodayLocalISO();
     setFormData(prev => ({ ...prev, date: today }));
   }, []);
 
@@ -196,7 +196,7 @@ const ReservationModal: React.FC<ReservationModalProps> = ({ spaceId, onClose })
               type="date"
               value={formData.date}
               onChange={(e) => setFormData({ ...formData, date: e.target.value })}
-              min={new Date().toISOString().split('T')[0]}
+              min={getTodayLocalISO()}
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
               required
             />

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -39,6 +39,10 @@ export const isTimeInRange = (time: string, start: string, end: string): boolean
   const timeMinutes = timeToMinutes(time);
   const startMinutes = timeToMinutes(start);
   const endMinutes = timeToMinutes(end);
-  
+
   return timeMinutes >= startMinutes && timeMinutes <= endMinutes;
+};
+
+export const getTodayLocalISO = (): string => {
+  return new Date().toLocaleDateString('en-CA');
 };


### PR DESCRIPTION
## Summary
- add a reusable helper to get today's date in local ISO format
- use the helper in the reservation modal and admin dashboard to align default dates and statistics

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e17192cad083309ff0fe4d6fd28866