### PR TITLE
Handle reservation errors with retry

### DIFF
--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -12,7 +12,7 @@ interface DashboardProps {
 const Dashboard: React.FC<DashboardProps> = ({ onViewChange }) => {
   const { user } = useAuth();
   const { spaces } = useSpaces();
-  const { reservations, getUserReservations } = useReservations();
+  const { reservations, reservationsError, reloadReservations, getUserReservations } = useReservations();
 
   if (!user) return null;
 
@@ -59,6 +59,18 @@ const Dashboard: React.FC<DashboardProps> = ({ onViewChange }) => {
           }
         </p>
       </div>
+
+      {reservationsError && (
+        <div className="mb-8 bg-red-50 border border-red-200 text-red-700 rounded-lg p-4">
+          <p className="font-medium">{reservationsError}</p>
+          <button
+            onClick={reloadReservations}
+            className="mt-3 inline-flex items-center px-4 py-2 bg-red-600 text-white text-sm font-medium rounded-md hover:bg-red-700 transition-colors"
+          >
+            Reintentar
+          </button>
+        </div>
+      )}
 
       {/* Stats Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">

--- a/src/components/Reservations/ReservationsList.tsx
+++ b/src/components/Reservations/ReservationsList.tsx
@@ -10,7 +10,7 @@ interface ReservationsListProps {
 
 const ReservationsList: React.FC<ReservationsListProps> = ({ isAdminView = false }) => {
   const { user } = useAuth();
-  const { reservations, cancelReservation, getUserReservations } = useReservations();
+  const { reservations, reservationsError, reloadReservations, cancelReservation, getUserReservations } = useReservations();
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('');
 
@@ -75,12 +75,24 @@ const ReservationsList: React.FC<ReservationsListProps> = ({ isAdminView = false
           {isAdminView ? 'Todas las Reservas' : 'Mis Reservas'}
         </h1>
         <p className="text-gray-600 mt-2">
-          {isAdminView 
+          {isAdminView
             ? 'Gestiona todas las reservas del sistema'
             : 'Administra tus reservas de espacios comunitarios'
           }
         </p>
       </div>
+
+      {reservationsError && (
+        <div className="mb-6 bg-red-50 border border-red-200 text-red-700 rounded-lg p-4">
+          <p className="font-medium">{reservationsError}</p>
+          <button
+            onClick={reloadReservations}
+            className="mt-3 inline-flex items-center px-4 py-2 bg-red-600 text-white text-sm font-medium rounded-md hover:bg-red-700 transition-colors"
+          >
+            Reintentar
+          </button>
+        </div>
+      )}
 
       {/* Filters */}
       <div className="bg-white rounded-lg shadow p-6 mb-8">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -64,6 +64,8 @@ export interface SpaceContextType {
 
 export interface ReservationContextType {
   reservations: Reservation[];
+  reservationsError: string | null;
+  reloadReservations: () => Promise<void>;
   addReservation: (reservation: Omit<Reservation, 'id' | 'createdAt' | 'status'>) => Promise<boolean>;
   cancelReservation: (id: string) => void;
   getUserReservations: (userId: string) => Reservation[];


### PR DESCRIPTION
## Summary
- capture Supabase errors when loading, creating, or cancelling reservations and persist the error state in context
- expose the reservation error and a reload helper to consumers through the ReservationContext type
- surface error alerts with retry actions in the reservations list and dashboard views

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e17794a07c8330bb2bb74ef80825ef