### PR TITLE
Add admin quick action navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,9 @@ import Dashboard from './components/Dashboard/Dashboard';
 import SpacesList from './components/Spaces/SpacesList';
 import ReservationsList from './components/Reservations/ReservationsList';
 import AdminPanel from './components/Admin/AdminPanel';
+import UserManagement from './components/Admin/UserManagement';
+import ReportsPanel from './components/Admin/ReportsPanel';
+import AdvancedSettings from './components/Admin/AdvancedSettings';
 
 const AppContent: React.FC = () => {
   const { user, isLoading } = useAuth();
@@ -39,7 +42,33 @@ const AppContent: React.FC = () => {
       case 'all-reservations':
         return <ReservationsList isAdminView={true} />;
       case 'admin-panel':
-        return user.role === 'admin' ? <AdminPanel /> : <Dashboard onViewChange={setCurrentView} />;
+        return user.role === 'admin' ? (
+          <AdminPanel
+            onManageUsers={() => setCurrentView('admin-users')}
+            onShowReports={() => setCurrentView('admin-reports')}
+            onOpenAdvancedSettings={() => setCurrentView('admin-advanced-settings')}
+          />
+        ) : (
+          <Dashboard onViewChange={setCurrentView} />
+        );
+      case 'admin-users':
+        return user.role === 'admin' ? (
+          <UserManagement onBack={() => setCurrentView('admin-panel')} />
+        ) : (
+          <Dashboard onViewChange={setCurrentView} />
+        );
+      case 'admin-reports':
+        return user.role === 'admin' ? (
+          <ReportsPanel onBack={() => setCurrentView('admin-panel')} />
+        ) : (
+          <Dashboard onViewChange={setCurrentView} />
+        );
+      case 'admin-advanced-settings':
+        return user.role === 'admin' ? (
+          <AdvancedSettings onBack={() => setCurrentView('admin-panel')} />
+        ) : (
+          <Dashboard onViewChange={setCurrentView} />
+        );
       default:
         return <Dashboard onViewChange={setCurrentView} />;
     }

--- a/src/components/Admin/AdminPanel.tsx
+++ b/src/components/Admin/AdminPanel.tsx
@@ -5,7 +5,17 @@ import { useReservations } from '../../context/ReservationContext';
 import { getTodayLocalISO } from '../../utils/dateUtils';
 import SpaceForm from '../Spaces/SpaceForm';
 
-const AdminPanel: React.FC = () => {
+type AdminPanelProps = {
+  onManageUsers?: () => void;
+  onShowReports?: () => void;
+  onOpenAdvancedSettings?: () => void;
+};
+
+const AdminPanel: React.FC<AdminPanelProps> = ({
+  onManageUsers,
+  onShowReports,
+  onOpenAdvancedSettings,
+}) => {
   const { spaces } = useSpaces();
   const { reservations } = useReservations();
   const [showSpaceForm, setShowSpaceForm] = useState(false);
@@ -206,17 +216,26 @@ const AdminPanel: React.FC = () => {
             Acciones Rápidas
           </h2>
           <div className="space-y-3">
-            <button className="w-full text-left p-4 rounded-lg border border-gray-200 hover:border-blue-500 hover:bg-blue-50 transition-all">
+            <button
+              onClick={onManageUsers}
+              className="w-full text-left p-4 rounded-lg border border-gray-200 hover:border-blue-500 hover:bg-blue-50 transition-all"
+            >
               <h3 className="font-medium text-gray-900">Gestionar Usuarios</h3>
               <p className="text-sm text-gray-500">Ver y administrar usuarios registrados</p>
             </button>
-            
-            <button className="w-full text-left p-4 rounded-lg border border-gray-200 hover:border-green-500 hover:bg-green-50 transition-all">
+
+            <button
+              onClick={onShowReports}
+              className="w-full text-left p-4 rounded-lg border border-gray-200 hover:border-green-500 hover:bg-green-50 transition-all"
+            >
               <h3 className="font-medium text-gray-900">Reportes</h3>
               <p className="text-sm text-gray-500">Generar reportes de uso y ocupación</p>
             </button>
-            
-            <button className="w-full text-left p-4 rounded-lg border border-gray-200 hover:border-purple-500 hover:bg-purple-50 transition-all">
+
+            <button
+              onClick={onOpenAdvancedSettings}
+              className="w-full text-left p-4 rounded-lg border border-gray-200 hover:border-purple-500 hover:bg-purple-50 transition-all"
+            >
               <h3 className="font-medium text-gray-900">Configuración Avanzada</h3>
               <p className="text-sm text-gray-500">Ajustar reglas y parámetros del sistema</p>
             </button>

--- a/src/components/Admin/AdvancedSettings.tsx
+++ b/src/components/Admin/AdvancedSettings.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Settings } from 'lucide-react';
+
+type AdvancedSettingsProps = {
+  onBack?: () => void;
+};
+
+const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({ onBack }) => {
+  return (
+    <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-10 space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          <div className="p-3 bg-purple-100 rounded-full">
+            <Settings className="h-6 w-6 text-purple-600" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Configuración Avanzada</h1>
+            <p className="text-gray-600">Personaliza reglas y parámetros específicos del sistema.</p>
+          </div>
+        </div>
+        {onBack && (
+          <button
+            onClick={onBack}
+            className="px-4 py-2 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-100 transition-colors"
+          >
+            Volver al Panel
+          </button>
+        )}
+      </div>
+
+      <div className="bg-white rounded-lg shadow p-6 space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Días máximos de anticipación</label>
+          <input
+            type="number"
+            defaultValue={30}
+            className="mt-1 w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-purple-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Máximo de reservas simultáneas por usuario</label>
+          <input
+            type="number"
+            defaultValue={3}
+            className="mt-1 w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-purple-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Mensaje de comunicación interna</label>
+          <textarea
+            defaultValue="Recuerda confirmar la disponibilidad antes de aprobar una reserva especial."
+            className="mt-1 w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-purple-500"
+            rows={4}
+          />
+        </div>
+        <button className="w-full bg-purple-600 text-white py-2 rounded-md hover:bg-purple-700 transition-colors">
+          Guardar cambios
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AdvancedSettings;

--- a/src/components/Admin/ReportsPanel.tsx
+++ b/src/components/Admin/ReportsPanel.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { BarChart3 } from 'lucide-react';
+
+type ReportsPanelProps = {
+  onBack?: () => void;
+};
+
+const ReportsPanel: React.FC<ReportsPanelProps> = ({ onBack }) => {
+  return (
+    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-10 space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          <div className="p-3 bg-green-100 rounded-full">
+            <BarChart3 className="h-6 w-6 text-green-600" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Reportes y Analíticas</h1>
+            <p className="text-gray-600">Visualiza métricas clave para la toma de decisiones.</p>
+          </div>
+        </div>
+        {onBack && (
+          <button
+            onClick={onBack}
+            className="px-4 py-2 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-100 transition-colors"
+          >
+            Volver al Panel
+          </button>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {["Uso mensual", "Reservas canceladas", "Espacios populares", "Ingresos estimados"].map((title) => (
+          <div key={title} className="bg-white rounded-lg shadow p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-2">{title}</h2>
+            <p className="text-sm text-gray-500">
+              Este es un panel de ejemplo que muestra cómo se visualizarán las métricas y gráficos del sistema.
+            </p>
+            <div className="mt-4 h-24 bg-gradient-to-r from-green-200 via-green-100 to-green-200 rounded" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ReportsPanel;

--- a/src/components/Admin/UserManagement.tsx
+++ b/src/components/Admin/UserManagement.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Users } from 'lucide-react';
+
+type UserManagementProps = {
+  onBack?: () => void;
+};
+
+const UserManagement: React.FC<UserManagementProps> = ({ onBack }) => {
+  return (
+    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-10 space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          <div className="p-3 bg-blue-100 rounded-full">
+            <Users className="h-6 w-6 text-blue-600" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Gestión de Usuarios</h1>
+            <p className="text-gray-600">Revisa y administra los usuarios registrados en la plataforma.</p>
+          </div>
+        </div>
+        {onBack && (
+          <button
+            onClick={onBack}
+            className="px-4 py-2 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-100 transition-colors"
+          >
+            Volver al Panel
+          </button>
+        )}
+      </div>
+
+      <div className="bg-white rounded-lg shadow divide-y">
+        {[1, 2, 3].map((user) => (
+          <div key={user} className="p-4 flex items-center justify-between">
+            <div>
+              <p className="font-medium text-gray-900">Usuario Ejemplo {user}</p>
+              <p className="text-sm text-gray-500">usuario{user}@correo.com</p>
+            </div>
+            <div className="flex space-x-2">
+              <button className="px-3 py-1 text-sm text-blue-600 border border-blue-200 rounded hover:bg-blue-50">
+                Ver detalles
+              </button>
+              <button className="px-3 py-1 text-sm text-red-600 border border-red-200 rounded hover:bg-red-50">
+                Desactivar
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default UserManagement;


### PR DESCRIPTION
## Summary
- add optional quick-action callbacks to the admin panel and wire them to buttons
- create dedicated admin views for user management, reports, and advanced settings with back navigation
- update the app view router to surface the new admin sections when callbacks are used

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e19d61f83083308679422b76f13791