### PR TITLE
Integrate Supabase data into admin user management

### DIFF
--- a/src/components/Admin/UserManagement.tsx
+++ b/src/components/Admin/UserManagement.tsx
@@ -1,11 +1,104 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Users } from 'lucide-react';
+import { supabase } from '../../lib/supabase';
 
 type UserManagementProps = {
   onBack?: () => void;
 };
 
+type Profile = {
+  id: string;
+  full_name: string | null;
+  email: string | null;
+  phone: string | null;
+  role: 'admin' | 'user' | null;
+  created_at: string | null;
+};
+
 const UserManagement: React.FC<UserManagementProps> = ({ onBack }) => {
+  const [users, setUsers] = useState<Profile[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [updatingUserId, setUpdatingUserId] = useState<string | null>(null);
+
+  const fetchUsers = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const { data, error: fetchError } = await supabase
+        .from('profiles')
+        .select('id, full_name, email, phone, role, created_at')
+        .order('created_at', { ascending: false });
+
+      if (fetchError) {
+        throw fetchError;
+      }
+
+      setUsers((data as Profile[]) ?? []);
+    } catch (fetchErr) {
+      const message = fetchErr instanceof Error ? fetchErr.message : 'No se pudieron cargar los usuarios.';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchUsers();
+  }, [fetchUsers]);
+
+  const handleToggleRole = async (user: Profile) => {
+    if (!user.id) return;
+
+    const currentRole = user.role === 'admin' ? 'admin' : 'user';
+    const nextRole = currentRole === 'admin' ? 'user' : 'admin';
+
+    try {
+      setUpdatingUserId(user.id);
+      setError(null);
+      const { error: updateError } = await supabase
+        .from('profiles')
+        .update({ role: nextRole })
+        .eq('id', user.id);
+
+      if (updateError) {
+        throw updateError;
+      }
+
+      await fetchUsers();
+    } catch (updateErr) {
+      const message = updateErr instanceof Error ? updateErr.message : 'No se pudo actualizar el rol del usuario.';
+      setError(message);
+    } finally {
+      setUpdatingUserId(null);
+    }
+  };
+
+  const handleDeactivateUser = async (user: Profile) => {
+    if (!user.id) return;
+
+    try {
+      setUpdatingUserId(user.id);
+      setError(null);
+      const { error: deactivateError } = await supabase
+        .from('profiles')
+        .update({ is_active: false } as Record<string, unknown>)
+        .eq('id', user.id);
+
+      if (deactivateError) {
+        throw deactivateError;
+      }
+
+      await fetchUsers();
+    } catch (deactivateErr) {
+      const message =
+        deactivateErr instanceof Error ? deactivateErr.message : 'No se pudo desactivar al usuario seleccionado.';
+      setError(message);
+    } finally {
+      setUpdatingUserId(null);
+    }
+  };
+
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-10 space-y-6">
       <div className="flex items-center justify-between">
@@ -29,22 +122,49 @@ const UserManagement: React.FC<UserManagementProps> = ({ onBack }) => {
       </div>
 
       <div className="bg-white rounded-lg shadow divide-y">
-        {[1, 2, 3].map((user) => (
-          <div key={user} className="p-4 flex items-center justify-between">
-            <div>
-              <p className="font-medium text-gray-900">Usuario Ejemplo {user}</p>
-              <p className="text-sm text-gray-500">usuario{user}@correo.com</p>
+        {loading && (
+          <div className="p-6 text-center text-gray-500">Cargando usuarios...</div>
+        )}
+
+        {error && !loading && (
+          <div className="p-4 text-sm text-red-600 bg-red-50 border-b border-red-100">{error}</div>
+        )}
+
+        {!loading && !error && users.length === 0 && (
+          <div className="p-6 text-center text-gray-500">No se encontraron usuarios registrados.</div>
+        )}
+
+        {!loading && !error &&
+          users.map((user) => (
+            <div key={user.id} className="p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+              <div>
+                <p className="font-medium text-gray-900">{user.full_name ?? 'Sin nombre'}</p>
+                <p className="text-sm text-gray-500">{user.email ?? 'Sin correo'}</p>
+                <p className="text-sm text-gray-400">
+                  Registrado el {user.created_at ? new Date(user.created_at).toLocaleDateString() : 'N/D'}
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <span className="px-3 py-1 text-xs font-semibold rounded-full bg-blue-50 text-blue-600">
+                  Rol: {user.role ?? 'N/D'}
+                </span>
+                <button
+                  onClick={() => handleToggleRole(user)}
+                  disabled={updatingUserId === user.id}
+                  className="px-3 py-1 text-sm text-blue-600 border border-blue-200 rounded hover:bg-blue-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {updatingUserId === user.id ? 'Actualizando...' : 'Cambiar rol'}
+                </button>
+                <button
+                  onClick={() => handleDeactivateUser(user)}
+                  disabled={updatingUserId === user.id}
+                  className="px-3 py-1 text-sm text-red-600 border border-red-200 rounded hover:bg-red-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {updatingUserId === user.id ? 'Actualizando...' : 'Desactivar'}
+                </button>
+              </div>
             </div>
-            <div className="flex space-x-2">
-              <button className="px-3 py-1 text-sm text-blue-600 border border-blue-200 rounded hover:bg-blue-50">
-                Ver detalles
-              </button>
-              <button className="px-3 py-1 text-sm text-red-600 border border-red-200 rounded hover:bg-red-50">
-                Desactivar
-              </button>
-            </div>
-          </div>
-        ))}
+          ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- load admin user management data from Supabase and manage loading/error states
- render profiles from state and refresh after Supabase updates for role changes and deactivation actions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1a1a2cd908330ad59d82c3442a747