### PR TITLE
Sync profile emails with Supabase auth

### DIFF
--- a/src/components/Admin/UserManagement.tsx
+++ b/src/components/Admin/UserManagement.tsx
@@ -1,19 +1,16 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Users } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
+import type { Database } from '../../lib/database.types';
 
 type UserManagementProps = {
   onBack?: () => void;
 };
 
-type Profile = {
-  id: string;
-  full_name: string | null;
-  email: string | null;
-  phone: string | null;
-  role: 'admin' | 'user' | null;
-  created_at: string | null;
-};
+type Profile = Pick<
+  Database['public']['Tables']['profiles']['Row'],
+  'id' | 'full_name' | 'email' | 'phone' | 'role' | 'created_at'
+>;
 
 const UserManagement: React.FC<UserManagementProps> = ({ onBack }) => {
   const [users, setUsers] = useState<Profile[]>([]);
@@ -34,7 +31,7 @@ const UserManagement: React.FC<UserManagementProps> = ({ onBack }) => {
         throw fetchError;
       }
 
-      setUsers((data as Profile[]) ?? []);
+      setUsers(data ?? []);
     } catch (fetchErr) {
       const message = fetchErr instanceof Error ? fetchErr.message : 'No se pudieron cargar los usuarios.';
       setError(message);
@@ -138,8 +135,8 @@ const UserManagement: React.FC<UserManagementProps> = ({ onBack }) => {
           users.map((user) => (
             <div key={user.id} className="p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
               <div>
-                <p className="font-medium text-gray-900">{user.full_name ?? 'Sin nombre'}</p>
-                <p className="text-sm text-gray-500">{user.email ?? 'Sin correo'}</p>
+                <p className="font-medium text-gray-900">{user.full_name || 'Sin nombre'}</p>
+                <p className="text-sm text-gray-500">{user.email || 'Sin correo'}</p>
                 <p className="text-sm text-gray-400">
                   Registrado el {user.created_at ? new Date(user.created_at).toLocaleDateString() : 'N/D'}
                 </p>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -37,7 +37,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     async (userId: string) => {
       const { data: profile, error } = await supabase
         .from('profiles')
-        .select('id, username, full_name, phone, role, created_at')
+        .select('id, username, full_name, email, phone, role, created_at')
         .eq('id', userId)
         .maybeSingle<ProfileRow>();
 
@@ -48,25 +48,15 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       }
 
       if (profile) {
-        const userData: User = {
+        setUser({
           id: profile.id,
           username: profile.username,
-          email: '',
+          email: profile.email,
           fullName: profile.full_name,
           phone: profile.phone,
           role: profile.role,
           createdAt: profile.created_at
-        };
-
-        const { data: authUser, error: authError } = await supabase.auth.getUser();
-
-        if (authError) {
-          console.error('Error loading auth user:', authError);
-        } else if (authUser.user?.email) {
-          userData.email = authUser.user.email;
-        }
-
-        setUser(userData);
+        });
       }
 
       setIsLoading(false);
@@ -150,6 +140,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           id: authData.user.id,
           username: userData.username,
           full_name: userData.fullName,
+          email: userData.email,
           phone: userData.phone,
           role: 'user'
         });

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -14,6 +14,7 @@ export interface Database {
           id: string
           username: string
           full_name: string
+          email: string
           phone: string
           role: 'admin' | 'user'
           created_at: string
@@ -23,6 +24,7 @@ export interface Database {
           id: string
           username: string
           full_name: string
+          email: string
           phone: string
           role?: 'admin' | 'user'
           created_at?: string
@@ -32,6 +34,7 @@ export interface Database {
           id?: string
           username?: string
           full_name?: string
+          email?: string
           phone?: string
           role?: 'admin' | 'user'
           created_at?: string


### PR DESCRIPTION
## Summary
- add the email column to the generated Supabase profile types and use it across the app
- persist the user's email when registering and rely on the profile value when loading sessions
- simplify admin user management by using typed profile data instead of manual casts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1ab85f65c8330bf51543d28e7eda6