### PR TITLE
Add profile is_active flag and admin controls

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -37,7 +37,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     async (userId: string) => {
       const { data: profile, error } = await supabase
         .from('profiles')
-        .select('id, username, full_name, phone, role, created_at')
+        .select('id, username, full_name, phone, role, is_active, created_at')
         .eq('id', userId)
         .maybeSingle<ProfileRow>();
 
@@ -55,7 +55,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           fullName: profile.full_name,
           phone: profile.phone,
           role: profile.role,
-          createdAt: profile.created_at
+          createdAt: profile.created_at,
+          isActive: profile.is_active
         };
 
         const { data: authUser, error: authError } = await supabase.auth.getUser();
@@ -151,7 +152,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           username: userData.username,
           full_name: userData.fullName,
           phone: userData.phone,
-          role: 'user'
+          role: 'user',
+          is_active: true
         });
 
       if (profileError) throw profileError;

--- a/src/data/initialData.ts
+++ b/src/data/initialData.ts
@@ -74,7 +74,8 @@ export const initialAdminUser: User = {
   fullName: 'Administrador Principal',
   phone: '+57 300 123 4567',
   role: 'admin',
-  createdAt: new Date().toISOString()
+  createdAt: new Date().toISOString(),
+  isActive: true
 };
 
 export const sampleReservations: Reservation[] = [

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -16,6 +16,7 @@ export interface Database {
           full_name: string
           phone: string
           role: 'admin' | 'user'
+          is_active: boolean
           created_at: string
           updated_at: string
         }
@@ -25,6 +26,7 @@ export interface Database {
           full_name: string
           phone: string
           role?: 'admin' | 'user'
+          is_active?: boolean
           created_at?: string
           updated_at?: string
         }
@@ -34,6 +36,7 @@ export interface Database {
           full_name?: string
           phone?: string
           role?: 'admin' | 'user'
+          is_active?: boolean
           created_at?: string
           updated_at?: string
         }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export interface User {
   phone: string;
   role: 'admin' | 'user';
   createdAt: string;
+  isActive: boolean;
 }
 
 export interface Space {

--- a/supabase/migrations/20240606120000_add_is_active_to_profiles.sql
+++ b/supabase/migrations/20240606120000_add_is_active_to_profiles.sql
@@ -1,0 +1,6 @@
+alter table public.profiles
+  add column if not exists is_active boolean not null default true;
+
+update public.profiles
+set is_active = true
+where is_active is null;


### PR DESCRIPTION
## Summary
- add a migration that introduces an `is_active` column on `public.profiles` and refresh the generated database types
- ensure new profiles store `is_active: true` and expose the flag through the auth context/user typing
- display and toggle the active state from the admin user management interface

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1ace25200833096896a589fcfcdf2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Admins can now activate or deactivate users with a single toggle.
  - Each user shows a clear Active/Inactive status badge.
- Style
  - Button labels and styling adapt to the user’s current status for better clarity.
- Chores
  - Added an active status field to user accounts; new users are active by default.
  - Initial admin user now explicitly marked as active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->