### PR TITLE
Fix email handling when loading user profile

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -37,7 +37,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     async (userId: string) => {
       const { data: profile, error } = await supabase
         .from('profiles')
-        .select('id, username, full_name, phone, role, is_active, created_at')
+        .select('id, username, full_name, phone, role, is_active, created_at, email')
         .eq('id', userId)
         .maybeSingle<ProfileRow>();
 
@@ -48,10 +48,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       }
 
       if (profile) {
-        setUser({
+        const userData: User = {
           id: profile.id,
           username: profile.username,
-          email: profile.email,
+          email: profile.email ?? '',
           fullName: profile.full_name,
           phone: profile.phone,
           role: profile.role,


### PR DESCRIPTION
## Summary
- include the email column when loading user profiles
- build the user object before updating state and sync the email with the auth user data

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1b5bb05cc8330a44564f1c756ed05