### PR TITLE
Add system settings table and update types

### DIFF
--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -126,6 +126,26 @@ export interface Database {
           updated_at?: string
         }
       }
+      system_settings: {
+        Row: {
+          id: string
+          max_advance_days: number
+          max_concurrent_reservations: number
+          internal_message: string
+        }
+        Insert: {
+          id?: string
+          max_advance_days?: number
+          max_concurrent_reservations?: number
+          internal_message?: string
+        }
+        Update: {
+          id?: string
+          max_advance_days?: number
+          max_concurrent_reservations?: number
+          internal_message?: string
+        }
+      }
     }
   }
 }

--- a/supabase/migrations/20240704120000_create_system_settings.sql
+++ b/supabase/migrations/20240704120000_create_system_settings.sql
@@ -1,0 +1,10 @@
+create table if not exists public.system_settings (
+  id text primary key default 'global'::text,
+  max_advance_days integer not null default 30,
+  max_concurrent_reservations integer not null default 3,
+  internal_message text not null default 'Recuerda confirmar la disponibilidad antes de aprobar una reserva especial.'
+);
+
+insert into public.system_settings (id)
+values ('global')
+on conflict (id) do nothing;


### PR DESCRIPTION
## Summary
- add system_settings table migration with default values and seeded global row
- extend generated Supabase types to include the new system_settings table

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1b67c7594833084f9a06934bc4cbe