### PR TITLE
Configure Vite dev server for LAN access

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,8 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  server: {
+    host: '0.0.0.0',
+    port: 5173,
+  },
 });


### PR DESCRIPTION
## Summary
- configure the Vite dev server to bind to 0.0.0.0 so it is reachable from the LAN
- update the dev npm script to pass --host so the startup banner shows the LAN URL

## Testing
- npm run dev *(fails: vite executable unavailable in the environment due to registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e1fd18b9888330b58a1dafb46f09a2