### PR TITLE
Add Supabase schedule fetch and modal loading states

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -80,5 +80,6 @@ export interface ReservationContextType {
   cancelReservation: (id: string) => void;
   getUserReservations: (userId: string) => Reservation[];
   getSpaceReservations: (spaceId: string, date?: string) => Reservation[];
+  fetchSpaceSchedule: (spaceId: string, date: string) => Promise<Reservation[]>;
   isTimeSlotAvailable: (spaceId: string, date: string, startTime: string, endTime: string) => Promise<boolean>;
 }


### PR DESCRIPTION
## Summary
- add an async fetchSpaceSchedule helper in the reservation context to query Supabase for active reservations by espacio y fecha
- expose the new helper through the context type so components can request schedules directly
- update the reservation modal to load schedules asynchronously with loading and error feedback when the date or reservation data changes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5395ac184833088bf354b42c28dfa