### PR TITLE
Add select and delete policies for payment proof storage objects

### DIFF
--- a/supabase/migrations/20251106120000_storage_payment_proofs_select_delete.sql
+++ b/supabase/migrations/20251106120000_storage_payment_proofs_select_delete.sql
@@ -1,0 +1,24 @@
+-- Ensure authenticated users can view and optionally delete payment proof uploads
+
+-- Drop existing SELECT and DELETE policies to avoid duplicates when re-running migrations
+DROP POLICY IF EXISTS "Allow payment proof downloads" ON storage.objects;
+DROP POLICY IF EXISTS "Allow payment proof deletions" ON storage.objects;
+
+-- Allow authenticated users to list and read objects in the payment-proofs bucket
+CREATE POLICY "Allow payment proof downloads"
+ON storage.objects
+FOR SELECT
+TO authenticated
+USING (
+  bucket_id = 'payment-proofs'
+);
+
+-- Allow authenticated users to delete only their own payment proof files
+CREATE POLICY "Allow payment proof deletions"
+ON storage.objects
+FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'payment-proofs'
+  AND owner = auth.uid()
+);


### PR DESCRIPTION
## Summary
- add a migration that drops outdated payment proof select/delete policies
- create select and delete policies for authenticated users scoped to the payment-proofs bucket

## Testing
- npx supabase db push --include-all *(fails: project not linked in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69177b998138833085cba0643e261b4e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated storage access policies to enable authenticated users to download and delete their payment proof files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->